### PR TITLE
fix(isNumericString): better error handling

### DIFF
--- a/sb2_to_cpp.py
+++ b/sb2_to_cpp.py
@@ -296,8 +296,7 @@ public:
         //note:
         //§7.22.1.3 (N1570)
         //If the result underflows (7.12.1); whether errno acquires the value ERANGE is implementation-defined.
-        return !(0 == re && s.c_str() == ep) || 0 == errno;
-        // TODO: In Scratch '000' is regarded as non-numeric (but here regarded as numeric)
+        return !(0 == re && s.c_str() == ep) && 0 == errno;
     }
     bool isNumeric() const{
         if (type == NUMBER) return true;

--- a/sb2_to_cpp.py
+++ b/sb2_to_cpp.py
@@ -261,6 +261,7 @@ def sb2_to_cpp(infilename_sb2):
 #include <vector>
 #include <algorithm>
 #include <math.h>
+#include <errno.h>
 #define debug cerr << "--" << __LINE__ << "--" << "\\n"
 using namespace std;
 
@@ -290,8 +291,12 @@ public:
     }
     static bool isNumericString(const string &s) {
         char* ep;
-        strtod(s.c_str(), &ep);
-        return !ep || !*ep;
+        errno = 0;
+        const double re = strtod(s.c_str(), &ep);
+        //note:
+        //§7.22.1.3 (N1570)
+        //If the result underflows (7.12.1); whether errno acquires the value ERANGE is implementation-defined.
+        return !(0 == re && s.c_str() == ep) || 0 == errno;
         // TODO: In Scratch '000' is regarded as non-numeric (but here regarded as numeric)
     }
     bool isNumeric() const{

--- a/sb2_to_cpp.py
+++ b/sb2_to_cpp.py
@@ -261,7 +261,6 @@ def sb2_to_cpp(infilename_sb2):
 #include <vector>
 #include <algorithm>
 #include <math.h>
-#include <errno.h>
 #define debug cerr << "--" << __LINE__ << "--" << "\\n"
 using namespace std;
 
@@ -291,14 +290,10 @@ public:
     }
     static bool isNumericString(const string &s) {
         char* ep;
-        errno = 0;
-        const double re = strtod(s.c_str(), &ep);
-        //note:
-        //§7.22.1.3 (N1570)
-        //If the result underflows (7.12.1); whether errno acquires the value ERANGE is implementation-defined.
-        //Scratch 3.0 recognize the string cause underflows or overflows as Numeric so that we ignore when `errno` is ERANGE
-        if(ERANGE == errno) errno = 0;
-        return !(0 == re && s.c_str() == ep) && 0 == errno && NULL != ep && '\0' == ep[0];
+        //cause side-effect: errno can be ERANGE after calling strtod
+        strtod(s.c_str(), &ep);
+        //Scratch 3.0 recognize the string cause underflows or overflows as Numeric
+        return s[0] != '\0' && NULL != ep && '\0' == ep[0];
     }
     bool isNumeric() const{
         if (type == NUMBER) return true;

--- a/sb2_to_cpp.py
+++ b/sb2_to_cpp.py
@@ -296,7 +296,9 @@ public:
         //note:
         //§7.22.1.3 (N1570)
         //If the result underflows (7.12.1); whether errno acquires the value ERANGE is implementation-defined.
-        return !(0 == re && s.c_str() == ep) && 0 == errno;
+        //Scratch 3.0 recognize the string cause underflows or overflows as Numeric so that we ignore when `errno` is ERANGE
+        if(ERANGE == errno) errno = 0;
+        return !(0 == re && s.c_str() == ep) && 0 == errno && NULL != ep && '\0' == ep[0];
     }
     bool isNumeric() const{
         if (type == NUMBER) return true;


### PR DESCRIPTION
To detect weather string is numeric correctly, we need to check the message from strtod by following below:

1. no conversion performed: return value is 0, the value of nptr(1st argument) is stored in the object pointed to by endptr(2nd argument)
2. other error: check errno value

However, it is impossible via strtod to check weather input string cause underflows portably
because whether errno acquires the value ERANGE is implementation-defined.

ref:
- https://qiita.com/yumetodo/items/238751b879c09b56234b